### PR TITLE
fix: SimpleMongoReader should allow optional fields in metadata

### DIFF
--- a/llama_index/readers/mongo.py
+++ b/llama_index/readers/mongo.py
@@ -95,7 +95,7 @@ class SimpleMongoReader(BaseReader):
                 yield Document(text=text)
             else:
                 try:
-                    metadata = {name: item[name] for name in metadata_names}
+                    metadata = {name: item.get(name) for name in metadata_names}
                 except KeyError as err:
                     raise ValueError(
                         f"{err.args[0]} field not found in Mongo document."


### PR DESCRIPTION
# Description

Not all metadata fields should be mandatorily present in all Mongo DB documents. If some fields are missing, take `None` as their value instead of crashing.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
